### PR TITLE
fix for systems without temp hp

### DIFF
--- a/getNewHP.js
+++ b/getNewHP.js
@@ -10,7 +10,7 @@
  */
 const getNewHP = (currentHP, maxHP, tempHP, value, options = {}) => {
   // Store the temp HP value
-  const tmp = Number(tempHP) ?? 0;
+  const tmp = tempHP != null ? Number(tempHP) : 0;
 
   // Calculate value to apply on temp only
   const dt = value > 0 ? Math.min(tmp, value) : 0;

--- a/getNewHP.test.js
+++ b/getNewHP.test.js
@@ -21,6 +21,15 @@ test('getNewHP should return the correct values', () => {
   expect(getNewHP(10, 10, 30, -5)).toEqual([10, 30]);
   expect(getNewHP(10, 10, 0, -5)).toEqual([10, 0]);
 
+  expect(getNewHP(10, 10, undefined, 2)).toEqual([8, 0]);
+  expect(getNewHP(1, 10, undefined, 2)).toEqual([0, 0]);
+  expect(getNewHP(0, 10, undefined, 2)).toEqual([0, 0]);
+  expect(getNewHP(8, 10, undefined, 2)).toEqual([6, 0]);
+  expect(getNewHP(10, 10, undefined, -2)).toEqual([10, 0]);
+  expect(getNewHP(8, 10, undefined, -2)).toEqual([10, 0]);
+  expect(getNewHP(0, 10, undefined, -2)).toEqual([2, 0]);
+  expect(getNewHP(10, 10, undefined, 0)).toEqual([10, 0]);
+
   const opts = {allowNegative: true};
   expect(getNewHP(10, 10, 30, 20, opts)).toEqual([10, 10]);
   expect(getNewHP(10, 10, 0, 10, opts)).toEqual([0, 0]);
@@ -30,4 +39,9 @@ test('getNewHP should return the correct values', () => {
   expect(getNewHP(10, 10, 0, 12, opts)).toEqual([-2, 0]);
   expect(getNewHP(0, 10, 0, 12, opts)).toEqual([-12, 0]);
   expect(getNewHP(0, 10, 0, -12, opts)).toEqual([10, 0]);
+
+  expect(getNewHP(10, 10, undefined, 10, opts)).toEqual([0, 0]);
+  expect(getNewHP(10, 10, undefined, 12, opts)).toEqual([-2, 0]);
+  expect(getNewHP(0, 10, undefined, 12, opts)).toEqual([-12, 0]);
+  expect(getNewHP(0, 10, undefined, -12, opts)).toEqual([10, 0]);
 });


### PR DESCRIPTION
Without this fix, the module does not work correctly when used with a system without temp hp. Whenever you would deduct hp from a token, the hit points are actually set to `null`. This is due to the fact that when there are no `tempHP`, the function `getNewHP` gets `undefined` as the corresponding parameter and tries to calculate `Number(undefined)`, which is `NaN`. Then everything else based on this value also becomes `NaN`.

With this PR, there is a (correct) check if `tempHP` is `null` or `undefined` to circumvent this problem.

Additionally this adds corresponding test cases.